### PR TITLE
Fix linting - Missing main list heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,12 @@
 		<img width="700" src="https://static1.squarespace.com/static/5b2d76525cfd790c4a218093/t/5f3845ab3384b2337c3214b9/1597523382325/Control_Map_ver4.png" alt="The Map of Control Theory by Brian Douglas">
 		<p><small><a href="https://www.redbubble.com/shop/ap/55089837">Map</a> by Brian Douglas</small></p>
 	</div>
-	<h1>Awesome Control Theory</h1>
-	<p>
-		<a href="https://en.wikipedia.org/wiki/Control_theory">Control theory</a> is a branch of applied mathematics that deals with the design of control policies for actuated dynamical systems. Control engineering is a cross-discipline field that applies control theory to a wide range of systems such as industrial plants, aerospace, robotics and more.
-	</p>
-	<a href="https://awesome.re">
-		<img src="https://awesome.re/badge-flat2.svg" alt="Awesome">
-	</a>
-	<br>
 </div>
+
+<!-- omit from toc -->
+# Awesome Control Theory [![awesome-badge](https://awesome.re/badge-flat2.svg)](https://awesome.re)
+
+[Control theory](https://en.wikipedia.org/wiki/Control_theory) is a branch of applied mathematics that deals with the design of control policies for actuated dynamical systems. Control engineering is a cross-discipline field that applies control theory to a wide range of systems such as industrial plants, aerospace, robotics and more.
 
 ## Contents
 


### PR DESCRIPTION
Fixes the following by converting the header to Markdown:

```
$ npx awesome-lint                                                    
✖ Linting

  README.md:1:1
  ✖  1:1  Missing main list heading  remark-lint:awesome-heading

  1 error
```